### PR TITLE
build(gha): updated docker image ci with latest

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -34,4 +34,6 @@ jobs:
           context: .
           file: Dockerfile
           push: true
-          tags: ${{ env.ORG }}/oai-harvester:${{ github.ref_name }}
+          tags: |
+            ${{ env.ORG }}/oai-harvester:${{ github.ref_name }}
+            ${{ env.ORG }}/oai-harvester:latest


### PR DESCRIPTION
The change expands the ci by having a second tag be created called `:latest` for each tag push.